### PR TITLE
Fix purge-cluster-cleanup.patch for stable-4.0 (pt2)

### DIFF
--- a/patches/stable-4.0/purge-cluster-cleanup.patch
+++ b/patches/stable-4.0/purge-cluster-cleanup.patch
@@ -10,10 +10,10 @@ index c5333ed8..22627b9b 100644
 -      path: "{{ fetch_directory }}"
 -      state: absent
 +    shell: "/bin/rm -rf {{ fetch_directory }}/*"
-diff --git a/infrastructure-playbooks/purge-docker-cluster.yml b/infrastructure-playbooks/purge-docker-cluster.yml
+diff --git a/infrastructure-playbooks/purge-container-cluster.yml b/infrastructure-playbooks/purge-container-cluster.yml
 index 8bcd7293..cbfaa2ea 100644
---- a/infrastructure-playbooks/purge-docker-cluster.yml
-+++ b/infrastructure-playbooks/purge-docker-cluster.yml
+--- a/infrastructure-playbooks/purge-container-cluster.yml
++++ b/infrastructure-playbooks/purge-container-cluster.yml
 @@ -469,142 +469,6 @@
          - /etc/prometheus
        failed_when: false


### PR DESCRIPTION
Required because of 1c03d2b52693e35161ab6c6a08a8d20c1c5c3dab