### PR TITLE
stable-5.0: fix always-use-ceph-uid-64045.patch

### DIFF
--- a/patches/stable-5.0/always-use-ceph-uid-64045.patch
+++ b/patches/stable-5.0/always-use-ceph-uid-64045.patch
@@ -1,11 +1,11 @@
 --- a/roles/ceph-defaults/defaults/main.yml
 +++ b/roles/ceph-defaults/defaults/main.yml
 @@ -245,7 +245,7 @@ generate_fsid: true
- 
+
  ceph_conf_key_directory: /etc/ceph
- 
--ceph_uid: "{{ '64045' if not containerized_deployment | bool and ansible_os_family == 'Debian' else '167' }}"
+
+-ceph_uid: "{{ '64045' if not containerized_deployment | bool and ansible_facts['os_family'] == 'Debian' else '167' }}"
 +ceph_uid: 64045
- 
+
  # Permissions for keyring files in /etc/ceph
  ceph_keyring_permissions: '0600'


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>