### PR TITLE
Install hiredis

### DIFF
--- a/files/src/templates/requirements.txt.j2
+++ b/files/src/templates/requirements.txt.j2
@@ -11,6 +11,7 @@ asn1crypto
 celery[redis]==5.2.0
 cryptography
 docker
+hiredis
 idna
 notario
 paramiko


### PR DESCRIPTION
UserWarning: redis-py works best with hiredis.

Signed-off-by: Christian Berendt <berendt@osism.tech>