### PR TITLE
Disable fail fast for container builds

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         ceph_version:
           - nautilus


### PR DESCRIPTION
We want to see all build results even if one of them fails.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>