### PR TITLE
Add ceph-boostrap-dashboard playbook

### DIFF
--- a/files/playbooks/master/ceph-bootstrap-dashboard.yml
+++ b/files/playbooks/master/ceph-bootstrap-dashboard.yml
@@ -1,0 +1,59 @@
+---
+- name: Bootstraph ceph dashboard
+  hosts: manager
+  gather_facts: false
+
+  tasks:
+    # NOTE: disable and re-enable the dashboard to trigger a restart of the dashboard
+    - name: Disable the ceph dashboard
+      ansible.builtin.command: ceph mgr module disable dashboard  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: Set mgr/dashboard/ssl to false
+      ansible.builtin.command: ceph config set mgr mgr/dashboard/ssl false  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: Set mgr/dashboard/server_port to 7000
+      ansible.builtin.command: ceph config set mgr mgr/dashboard/server_port 7000  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: Enable the ceph dashboard
+      ansible.builtin.command: ceph mgr module enable dashboard  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: Write ceph_dashboard_password to temporary file
+      ansible.builtin.copy:
+        content: "{{ ceph_dashboard_password }}"
+        dest: /opt/cephclient/data/ceph_dashboard_password
+        mode: 0644
+      no_log: true
+
+    - name: Create admin user
+      ansible.builtin.command: "ceph dashboard ac-user-create {{ ceph_dashboard_username }} administrator -i /data/ceph_dashboard_password"  # noqa 301
+      register: result
+      changed_when: "'already exists' not in result.stderr"
+      failed_when: ( result.rc not in [ 0, 17 ] )
+      environment:
+        INTERACTIVE: false
+
+    - name: Remove temporary file for ceph_dashboard_password
+      ansible.builtin.file:
+        path: /opt/cephclient/data/ceph_dashboard_password
+        state: absent
+      when: tempfile.path is defined
+
+- name: Restart ceph manager services
+  hosts: ceph-mon
+  gather_facts: false
+  serial: 1
+
+  tasks:
+    - name: Restart ceph manager service
+      become: true
+      ansible.builtin.service:
+        name: "ceph-mgr@{{ inventory_hostname_short }}"
+        state: restarted

--- a/files/playbooks/octopus/ceph-bootstrap-dashboard.yml
+++ b/files/playbooks/octopus/ceph-bootstrap-dashboard.yml
@@ -1,0 +1,59 @@
+---
+- name: Bootstraph ceph dashboard
+  hosts: manager
+  gather_facts: false
+
+  tasks:
+    # NOTE: disable and re-enable the dashboard to trigger a restart of the dashboard
+    - name: Disable the ceph dashboard
+      ansible.builtin.command: ceph mgr module disable dashboard  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: Set mgr/dashboard/ssl to false
+      ansible.builtin.command: ceph config set mgr mgr/dashboard/ssl false  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: Set mgr/dashboard/server_port to 7000
+      ansible.builtin.command: ceph config set mgr mgr/dashboard/server_port 7000  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: Enable the ceph dashboard
+      ansible.builtin.command: ceph mgr module enable dashboard  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: Write ceph_dashboard_password to temporary file
+      ansible.builtin.copy:
+        content: "{{ ceph_dashboard_password }}"
+        dest: /opt/cephclient/data/ceph_dashboard_password
+        mode: 0644
+      no_log: true
+
+    - name: Create admin user
+      ansible.builtin.command: "ceph dashboard ac-user-create {{ ceph_dashboard_username }} administrator -i /data/ceph_dashboard_password"  # noqa 301
+      register: result
+      changed_when: "'already exists' not in result.stderr"
+      failed_when: ( result.rc not in [ 0, 17 ] )
+      environment:
+        INTERACTIVE: false
+
+    - name: Remove temporary file for ceph_dashboard_password
+      ansible.builtin.file:
+        path: /opt/cephclient/data/ceph_dashboard_password
+        state: absent
+      when: tempfile.path is defined
+
+- name: Restart ceph manager services
+  hosts: ceph-mon
+  gather_facts: false
+  serial: 1
+
+  tasks:
+    - name: Restart ceph manager service
+      become: true
+      ansible.builtin.service:
+        name: "ceph-mgr@{{ inventory_hostname_short }}"
+        state: restarted

--- a/files/playbooks/pacific/ceph-bootstrap-dashboard.yml
+++ b/files/playbooks/pacific/ceph-bootstrap-dashboard.yml
@@ -1,0 +1,59 @@
+---
+- name: Bootstraph ceph dashboard
+  hosts: manager
+  gather_facts: false
+
+  tasks:
+    # NOTE: disable and re-enable the dashboard to trigger a restart of the dashboard
+    - name: Disable the ceph dashboard
+      ansible.builtin.command: ceph mgr module disable dashboard  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: Set mgr/dashboard/ssl to false
+      ansible.builtin.command: ceph config set mgr mgr/dashboard/ssl false  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: Set mgr/dashboard/server_port to 7000
+      ansible.builtin.command: ceph config set mgr mgr/dashboard/server_port 7000  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: Enable the ceph dashboard
+      ansible.builtin.command: ceph mgr module enable dashboard  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: Write ceph_dashboard_password to temporary file
+      ansible.builtin.copy:
+        content: "{{ ceph_dashboard_password }}"
+        dest: /opt/cephclient/data/ceph_dashboard_password
+        mode: 0644
+      no_log: true
+
+    - name: Create admin user
+      ansible.builtin.command: "ceph dashboard ac-user-create {{ ceph_dashboard_username }} administrator -i /data/ceph_dashboard_password"  # noqa 301
+      register: result
+      changed_when: "'already exists' not in result.stderr"
+      failed_when: ( result.rc not in [ 0, 17 ] )
+      environment:
+        INTERACTIVE: false
+
+    - name: Remove temporary file for ceph_dashboard_password
+      ansible.builtin.file:
+        path: /opt/cephclient/data/ceph_dashboard_password
+        state: absent
+      when: tempfile.path is defined
+
+- name: Restart ceph manager services
+  hosts: ceph-mon
+  gather_facts: false
+  serial: 1
+
+  tasks:
+    - name: Restart ceph manager service
+      become: true
+      ansible.builtin.service:
+        name: "ceph-mgr@{{ inventory_hostname_short }}"
+        state: restarted


### PR DESCRIPTION
The Playbook comes out of the testbed. It makes sense to have it here.
Then it can be used everywhere and does not have to be maintained as
a custom playbook.

Signed-off-by: Christian Berendt <berendt@osism.tech>