### PR TITLE
Pin ansible.netcommon collection to 2.5.0

### DIFF
--- a/files/requirements.yml
+++ b/files/requirements.yml
@@ -8,5 +8,5 @@ collections:
     source: https://galaxy.ansible.com
   # NOT: pin ansible.netcommon version because of osism/testbed#1236
   - name: ansible.netcommon
-    version: "2.6.1"
+    version: "2.5.0"
     source: https://galaxy.ansible.com


### PR DESCRIPTION
Version before 2.6.0 is necessary to not include the
"ipaddr migration to utils" commit
(db4920ebf6bae6476ff8829e2cf475f19f83a990).

This is the commit that causes the error in ceph-ansible.

Signed-off-by: Christian Berendt <berendt@osism.tech>