### PR TITLE
Render playbooks

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -178,6 +178,9 @@ RUN mkdir -p /tests \
 # copy ara configuration
 RUN python3 -m ara.setup.env > /ansible/ara.env
 
+# prepare list of playbooks
+RUN python3 /src/render-playbooks.py
+
 # set correct permssions
 RUN chown -R dragon: /ansible /share /interface
 

--- a/files/scripts/entrypoint.sh
+++ b/files/scripts/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-mkdir -p /interface/ceph-ansible /interface/versions
+mkdir -p /interface/ceph-ansible /interface/versions /interface/playbooks
 rsync -am --exclude='requirements*.yml' --include='*.yml' --exclude='*' /ansible/ /interface/ceph-ansible/
 cp /ansible/group_vars/all/versions.yml /interface/versions/ceph-ansible.yml
+cp /ansible/playbooks.yml /interface/playbooks/ceph-ansible.yml
 
 exec /usr/bin/dumb-init -- "$@"

--- a/files/src/render-playbooks.py
+++ b/files/src/render-playbooks.py
@@ -1,0 +1,16 @@
+# This script writes a list of all existing playbooks to /ansible/playbooks.yml.
+
+from pathlib import Path
+
+import yaml
+
+PREFIX = "ceph"
+
+result = {}
+
+for path in Path("/ansible").glob(f"{PREFIX}-*.yml"):
+    name = path.with_suffix("").name
+    result[name] = PREFIX
+
+with open("/ansible/playbooks.yml", "w+") as fp:
+    fp.write(yaml.dump(result))


### PR DESCRIPTION
This script writes a list of all existing playbooks to /ansible/playbooks.yml.

Signed-off-by: Christian Berendt <berendt@osism.tech>