### PR TITLE
ansible-lint: ignore purge playboks

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,14 @@
 ---
 exclude_paths:
   - .github
+  - files/playbooks/master/ceph-purge-storage-node.yml   # exclude playbooks imported from the ceph-ansible upstream
+  - files/playbooks/master/ceph-purge-cluster.yml        # exclude playbooks imported from the ceph-ansible upstream
+  - files/playbooks/octopus/ceph-purge-storage-node.yml  # exclude playbooks imported from the ceph-ansible upstream
+  - files/playbooks/octopus/ceph-purge-cluster.yml       # exclude playbooks imported from the ceph-ansible upstream
+  - files/playbooks/pacific/ceph-purge-storage-node.yml  # exclude playbooks imported from the ceph-ansible upstream
+  - files/playbooks/pacific/ceph-purge-cluster.yml       # exclude playbooks imported from the ceph-ansible upstream
+  - files/playbooks/quincy/ceph-purge-storage-node.yml   # exclude playbooks imported from the ceph-ansible upstream
+  - files/playbooks/quincy/ceph-purge-cluster.yml        # exclude playbooks imported from the ceph-ansible upstream
 use_default_rules: true
 rulesdir:
   - ./.ansible-lint-rules/


### PR DESCRIPTION
exclude playbooks imported from the ceph-ansible upstream