### PR TITLE
zuul: use latest as default version

### DIFF
--- a/playbooks/build.yml
+++ b/playbooks/build.yml
@@ -6,7 +6,7 @@
     ceph_version: "{{ version_ceph }}"
     registry: "{{ docker_registry }}"
     repository: "{{ docker_namespace }}/ceph-ansible"
-    version: "{{ zuul['tag'] | default(version_ceph) }}"
+    version: "{{ zuul['tag'] | default('latest') }}"
 
   tasks:
     - name: Log into registry


### PR DESCRIPTION
This reverts 9e5d5a9a07a4313bc4772914e7d23856e5c10f69.