### PR TITLE
Revert "chore(deps): update dependency opendev.org/openstack/ansible-…

### DIFF
--- a/files/requirements.yml
+++ b/files/requirements.yml
@@ -11,7 +11,7 @@ collections:
     version: "2.6.1"
     source: https://galaxy.ansible.com
   - name: https://opendev.org/openstack/ansible-config_template
-    version: 2.1.0
+    version: 2.0.0
     type: git
   - name: ansible.utils
     version: '>=2.5.0'


### PR DESCRIPTION
…config_template to v2.1.0 (#396)"

Something is currently not working with the "ceph monitor mkfs with keyring" task.

This reverts commit b3528dc1689296be928dc918470132e2e076bbc5.