### PR TITLE
Install osism.commons collection

### DIFF
--- a/files/requirements.yml
+++ b/files/requirements.yml
@@ -17,3 +17,5 @@ collections:
     version: '>=2.5.0'
   - name: community.general
   - name: ansible.posix
+  - name: osism.commons
+    source: https://galaxy.ansible.com


### PR DESCRIPTION
Required to be able to use the still_alive callback plugin.