### PR TITLE
Revert "Define undefined parameters (#443)"

### DIFF
--- a/files/playbooks/quincy/ceph-configure-lvm-volumes.yml
+++ b/files/playbooks/quincy/ceph-configure-lvm-volumes.yml
@@ -139,16 +139,6 @@
             _lvm_volumes_block_wal: []
             _lvm_volumes_block_db_wal: []
 
-        - name: Set ceph_db_devices if not defined
-          ansible.builtin.set_fact:
-            ceph_db_devices: {}
-          when: ceph_db_devices is not defined
-
-        - name: Set ceph_wal_devices if not defined
-          ansible.builtin.set_fact:
-            ceph_wal_devices: {}
-          when: ceph_wal_devices is not defined
-
         - name: Generate lvm_volumes structure (block only)
           ansible.builtin.set_fact:
             _lvm_volumes_block: >-


### PR DESCRIPTION
This is not required and makes the generated configuration unusable.

This reverts commit af1803bbe566961510be4904c9674b7039262974.

Related to osism/issues#888