### PR TITLE
[ceph-dashboard] Make standby behaviour and status code configurable

### DIFF
--- a/files/playbooks/quincy/ceph-bootstrap-dashboard.yml
+++ b/files/playbooks/quincy/ceph-bootstrap-dashboard.yml
@@ -9,6 +9,12 @@
     ceph_dashboard_password: password
     ceph_dashboard_port: 7000
     ceph_dashboard_username: admin
+    # NOTE: Allow customisation of standby behaviour and error status code
+    #       Use upstream defaults as default:
+    #       https://docs.ceph.com/en/quincy/mgr/dashboard/#disable-the-redirection
+    #       https://docs.ceph.com/en/quincy/mgr/dashboard/#configure-the-error-status-code
+    ceph_dashboard_standby_behaviour: redirect
+    ceph_dashboard_standby_error_status_code: 503
 
   tasks:
     # NOTE: disable and re-enable the dashboard to trigger a restart of the dashboard
@@ -29,6 +35,16 @@
 
     - name: "Set mgr/dashboard/server_addr to {{ ceph_dashboard_addr }}"
       ansible.builtin.command: "ceph config set mgr mgr/dashboard/server_addr {{ ceph_dashboard_addr }}"  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: "Set mgr/dashboard/standby_behaviour to {{ ceph_dashboard_standby_behaviour }}"
+      ansible.builtin.command: "ceph config set mgr mgr/dashboard/standby_behaviour {{ ceph_dashboard_standby_behaviour }}"  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: "Set mgr/dashboard/standby_error_status_code to {{ ceph_dashboard_standby_error_status_code }}"
+      ansible.builtin.command: "ceph config set mgr mgr/dashboard/standby_error_status_code {{ ceph_dashboard_standby_error_status_code }}"  # noqa 301
       environment:
         INTERACTIVE: false
 

--- a/files/playbooks/reef/ceph-bootstrap-dashboard.yml
+++ b/files/playbooks/reef/ceph-bootstrap-dashboard.yml
@@ -9,6 +9,12 @@
     ceph_dashboard_password: password
     ceph_dashboard_port: 7000
     ceph_dashboard_username: admin
+    # NOTE: Allow customisation of standby behaviour and error status code
+    #       Use upstream defaults as default:
+    #       https://docs.ceph.com/en/reef/mgr/dashboard/#disable-the-redirection
+    #       https://docs.ceph.com/en/reef/mgr/dashboard/#configure-the-error-status-code
+    ceph_dashboard_standby_behaviour: redirect
+    ceph_dashboard_standby_error_status_code: 503
 
   tasks:
     # NOTE: disable and re-enable the dashboard to trigger a restart of the dashboard
@@ -29,6 +35,16 @@
 
     - name: "Set mgr/dashboard/server_addr to {{ ceph_dashboard_addr }}"
       ansible.builtin.command: "ceph config set mgr mgr/dashboard/server_addr {{ ceph_dashboard_addr }}"  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: "Set mgr/dashboard/standby_behaviour to {{ ceph_dashboard_standby_behaviour }}"
+      ansible.builtin.command: "ceph config set mgr mgr/dashboard/standby_behaviour {{ ceph_dashboard_standby_behaviour }}"  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: "Set mgr/dashboard/standby_error_status_code to {{ ceph_dashboard_standby_error_status_code }}"
+      ansible.builtin.command: "ceph config set mgr mgr/dashboard/standby_error_status_code {{ ceph_dashboard_standby_error_status_code }}"  # noqa 301
       environment:
         INTERACTIVE: false
 


### PR DESCRIPTION
Allow to configure the ceph dashboard's options `standby_behaviour` ([1]) and `standby_error_status_code` ([2]).
While keeping the current default to redirect, this allows to adapt the behaviour to be more compatible with deployment behind a loadbalancer, where a redirect to a possibly internal URL is less useful than an error.

Especially in the case of a deployment behind `haproxy` one may set

```
ceph_dashboard_standby_behaviour: error
ceph_dashboard_standby_error_status_code: 404
```

and configure haproxy to

```
http-check expect status 200,404
http-check disable-on-404
```

where the former will set the backend "UP" on status codes 200 and 404, while latter will immediately transition the server to the "NOLB" status, thus not marking passive instances as down, while they are actually functioning correctly.

[1]
https://docs.ceph.com/en/quincy/mgr/dashboard/#disable-the-redirection

[2]
https://docs.ceph.com/en/quincy/mgr/dashboard/#configure-the-error-status-code