### PR TITLE
Remove release notes

### DIFF
--- a/releasenotes/notes/bookwork-dd53c1282742338b.yaml
+++ b/releasenotes/notes/bookwork-dd53c1282742338b.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Use Debian Bookworm as base image.

--- a/releasenotes/notes/ceph-pools-c1bc11fac2d14921.yaml
+++ b/releasenotes/notes/ceph-pools-c1bc11fac2d14921.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    With the `ceph-pools` play it is possible to manage the ceph pools independent
-    of the `ceph-osds` play.

--- a/releasenotes/notes/change-osism-d4c41adce8c34421.yaml
+++ b/releasenotes/notes/change-osism-d4c41adce8c34421.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    With the `change-osism.sh` script it is possible to install a different
-    python-osism version in a running inventory reconciler service.

--- a/releasenotes/notes/make-dashboard-addr-and-host-configurable-2f71e51f8fbf5822.yaml
+++ b/releasenotes/notes/make-dashboard-addr-and-host-configurable-2f71e51f8fbf5822.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    It is now possible to configure the port and address of the Ceph dashboard service
-    with the arguments `ceph_dashboard_port` (7000 by default) and `ceph_dashboard_addr`
-    (0.0.0.0 by default).

--- a/releasenotes/notes/multistage-build-912f801eb2370776.yaml
+++ b/releasenotes/notes/multistage-build-912f801eb2370776.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Use multi-stage build.

--- a/releasenotes/notes/remove-json-stats-ansible-module-8bc9da2c368b2c6c.yaml
+++ b/releasenotes/notes/remove-json-stats-ansible-module-8bc9da2c368b2c6c.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    The json_stats Ansible module is no longer required by python-osism and has been removed.

--- a/releasenotes/notes/remove-mitogen-3f4bfe83b38d97c6.yaml
+++ b/releasenotes/notes/remove-mitogen-3f4bfe83b38d97c6.yaml
@@ -1,7 +1,0 @@
----
-upgrade:
-  - |
-    The Mitogen plugin was deprecated and has now been removed. It was no
-    longer usable with current Ansible versions and the upstream was not
-    very active. If the Mitogen plugin is used in a configuration repository
-    via the Ansible configuration, this must be removed respectively.

--- a/releasenotes/notes/remove-pacific-0f8fc359cbfb0fc6.yaml
+++ b/releasenotes/notes/remove-pacific-0f8fc359cbfb0fc6.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Remove pacific build.


### PR DESCRIPTION
We manage the release notes again in the central osism/release and osism/osism.github.io repository.