### PR TITLE
Do not set container_binary fact

### DIFF
--- a/patches/stable-7.0/container-binary.patch
+++ b/patches/stable-7.0/container-binary.patch
@@ -1,0 +1,12 @@
+--- a/roles/ceph-facts/tasks/facts.yml
++++ b/roles/ceph-facts/tasks/facts.yml
+@@ -8,9 +8,6 @@
+   set_fact:
+     is_atomic: "{{ stat_ostree.stat.exists }}"
+
+-- name: import_tasks container_binary.yml
+-  import_tasks: container_binary.yml
+-
+ - name: set_fact ceph_cmd
+   set_fact:
+     ceph_cmd: "{{ container_binary + ' run --rm --net=host -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph:/var/lib/ceph:z -v /var/run/ceph:/var/run/ceph:z --entrypoint=ceph ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'ceph' }}"

--- a/patches/stable-8.0/container-binary.patch
+++ b/patches/stable-8.0/container-binary.patch
@@ -1,0 +1,12 @@
+--- a/roles/ceph-facts/tasks/facts.yml
++++ b/roles/ceph-facts/tasks/facts.yml
+@@ -8,9 +8,6 @@
+   ansible.builtin.set_fact:
+     is_atomic: "{{ stat_ostree.stat.exists }}"
+
+-- name: Import_tasks container_binary.yml
+-  ansible.builtin.import_tasks: container_binary.yml
+-
+ - name: Set_fact ceph_cmd
+   ansible.builtin.set_fact:
+     ceph_cmd: "{{ container_binary + ' run --rm --net=host -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph:/var/lib/ceph:z -v /var/run/ceph:/var/run/ceph:z --entrypoint=ceph ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'ceph' }}"


### PR DESCRIPTION
We adde container_binary to osism/defaults. This way it is configurable via the configuration repository.